### PR TITLE
Feature | Announcements search endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.20",
+    "version": "0.40.21",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
+++ b/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean } from "class-validator";
+
+import { OffsetPaginationDto } from "@/find-me-commons/dto/offset-pagination.dto";
+
+export class SearchFindMeAnnouncementDto extends OffsetPaginationDto {
+    @ApiProperty({ example: false })
+    @IsBoolean()
+    public onlyActive: boolean;
+
+    @ApiProperty({ example: false })
+    @IsBoolean()
+    public onlyFavorites: boolean;
+}

--- a/src/find-me-announcements/find-me-announcements.module.ts
+++ b/src/find-me-announcements/find-me-announcements.module.ts
@@ -26,6 +26,7 @@ import { FindMeDistinctiveFeaturesService }
     from "@/find-me-announcements/services/find-me-distinctive-features.service";
 import { FindMeFavoriteAnnouncementsService }
     from "@/find-me-announcements/services/find-me-favorite-announcements.service";
+import { FindMeUsersModule } from "@/find-me-users/find-me-users.module";
 
 @Module({
     imports: [
@@ -37,6 +38,7 @@ import { FindMeFavoriteAnnouncementsService }
             FindMeAnnouncement,
             FindMeFavoriteAnnouncement,
         ]),
+        FindMeUsersModule,
     ],
     providers: [
         FindMeDistinctiveFeaturesService,

--- a/src/find-me-commons/dto/offset-pagination.dto.ts
+++ b/src/find-me-commons/dto/offset-pagination.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class OffsetPaginationDto {
+    @ApiProperty({ example: 10 })
+    public pageSize: number;
+
+    @ApiProperty({ example: 0 })
+    public offset: number;
+}


### PR DESCRIPTION
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/39082174/166124783-01c8602f-3e06-479d-aa4b-9cbde56560fe.png">

Mamy teraz dwa nowe endpointy do wyszukiwania ogłoszeń

Wyszukiwanie swoich ogłoszeń
```
[POST]
/announcements/my/search
```

Wyszukiwanie ogłoszeń innego użytkownika po ID usera
```
[POST]
/announcements/other/{id}/search
```

Formularz wyszukiwania (body requesta) jest taki sam i tu i tu oraz zwracają identyczne obiekty

```
{
  "pageSize": 10,
  "offset": 0,
  "onlyActive": false,
  "onlyFavorites": false
}
```

## !!! To nie jest endpoint do wyszukiwania wszystkich ogłoszeń tylko na profile userów - do wyszukiwania wszystkich ogłoszeń będzie bardziej zaawansowany formularz