### PR TITLE
FM-199 | User view announcements logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.22",
+    "version": "0.40.23",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/controllers/find-me-announcements.controller.ts
+++ b/src/find-me-announcements/controllers/find-me-announcements.controller.ts
@@ -16,6 +16,8 @@ import { CreateFindMeAnnouncementDto } from "@/find-me-announcements/dto/create-
 import { GetFindMeAnnouncementDto } from "@/find-me-announcements/dto/get-find-me-announcement-dto";
 import { SearchFindMeAnnouncementDto } from "@/find-me-announcements/dto/search-find-me-announcement.dto";
 import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
+import { FindMeAnnouncementViewLogsService }
+    from "@/find-me-announcements/services/find-me-announcement-view-logs.service";
 import { FindMeAnnouncementsService } from "@/find-me-announcements/services/find-me-announcements.service";
 import { FindMeFavoriteAnnouncementsService }
     from "@/find-me-announcements/services/find-me-favorite-announcements.service";
@@ -36,7 +38,8 @@ export class FindMeAnnouncementsController {
     public constructor(
         private announcementsService: FindMeAnnouncementsService,
         private favoriteAnnouncementsService: FindMeFavoriteAnnouncementsService,
-        private usersService: FindMeUsersService
+        private usersService: FindMeUsersService,
+        private announcementViewLogsService: FindMeAnnouncementViewLogsService
     ) { }
 
     @ApiOperation({
@@ -157,6 +160,7 @@ export class FindMeAnnouncementsController {
         const announcement = await this.announcementsService.getAnnouncementById(announcementId);
         const isUserCreator = await this.announcementsService.isUserCreatorOfAnnouncement(user, announcement);
         const isInFavorites = await this.favoriteAnnouncementsService.isAnnouncementInUserFavorites(announcement, user);
+        if (!isUserCreator) await this.announcementViewLogsService.logAnnouncementViewByUser(announcement, user);
         return {
             ...announcement,
             isUserCreator,

--- a/src/find-me-announcements/entities/find-me-announcement-get-log.entity.ts
+++ b/src/find-me-announcements/entities/find-me-announcement-get-log.entity.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+@Entity()
+export class FindMeAnnouncementViewLog {
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+    @ApiProperty()
+    @ManyToOne(() => FindMeAnnouncement)
+    public viewedAnnouncement: FindMeAnnouncement;
+
+    @ApiProperty()
+    @ManyToOne(() => FindMeUser)
+    public viewingUser: FindMeUser;
+
+    @ApiProperty()
+    @CreateDateColumn()
+    public viewDate: Date;
+}

--- a/src/find-me-announcements/find-me-announcements.module.ts
+++ b/src/find-me-announcements/find-me-announcements.module.ts
@@ -13,6 +13,7 @@ import { FindMeFavoriteAnnouncementsController }
     from "@/find-me-announcements/controllers/find-me-favorite-announcements.controller";
 import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
 import { FindMeAnnouncementCategory } from "@/find-me-announcements/entities/find-me-announcement-category.entity";
+import { FindMeAnnouncementViewLog } from "@/find-me-announcements/entities/find-me-announcement-get-log.entity";
 import { FindMeAnnouncementPhoto } from "@/find-me-announcements/entities/find-me-announcement-photo.entity";
 import { FindMeCoatColor } from "@/find-me-announcements/entities/find-me-coat-color.entity";
 import { FindMeDistinctiveFeature } from "@/find-me-announcements/entities/find-me-distinctive-feature.entity";
@@ -37,6 +38,7 @@ import { FindMeUsersModule } from "@/find-me-users/find-me-users.module";
             FindMeAnnouncementPhoto,
             FindMeAnnouncement,
             FindMeFavoriteAnnouncement,
+            FindMeAnnouncementViewLog,
         ]),
         FindMeUsersModule,
     ],

--- a/src/find-me-announcements/find-me-announcements.module.ts
+++ b/src/find-me-announcements/find-me-announcements.module.ts
@@ -21,6 +21,8 @@ import { FindMeFavoriteAnnouncement } from "@/find-me-announcements/entities/fin
 import { FindMeAnnouncementCategoriesService }
     from "@/find-me-announcements/services/find-me-announcement-categories.service";
 import { FindMeAnnouncementPhotosService } from "@/find-me-announcements/services/find-me-announcement-photos.service";
+import { FindMeAnnouncementViewLogsService }
+    from "@/find-me-announcements/services/find-me-announcement-view-logs.service";
 import { FindMeAnnouncementsService } from "@/find-me-announcements/services/find-me-announcements.service";
 import { FindMeCoatColorsService } from "@/find-me-announcements/services/find-me-coat-colors.service";
 import { FindMeDistinctiveFeaturesService }
@@ -49,6 +51,7 @@ import { FindMeUsersModule } from "@/find-me-users/find-me-users.module";
         FindMeAnnouncementPhotosService,
         FindMeAnnouncementsService,
         FindMeFavoriteAnnouncementsService,
+        FindMeAnnouncementViewLogsService,
     ],
     controllers: [
         FindMeDistinctiveFeaturesController,

--- a/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
+++ b/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 
+import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
 import { FindMeAnnouncementViewLog } from "@/find-me-announcements/entities/find-me-announcement-get-log.entity";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
 
 @Injectable()
 export class FindMeAnnouncementViewLogsService {
@@ -10,4 +12,12 @@ export class FindMeAnnouncementViewLogsService {
         @InjectRepository(FindMeAnnouncementViewLog)
         private announcementViewLogsRepository: Repository<FindMeAnnouncementViewLog>
     ) { }
+
+    public async logAnnouncementViewByUser(announcement: FindMeAnnouncement, user: FindMeUser): Promise<void> {
+        const viewLog = this.announcementViewLogsRepository.create({
+            viewedAnnouncement: announcement,
+            viewingUser: user,
+        });
+        await this.announcementViewLogsRepository.save(viewLog);
+    }
 }

--- a/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
+++ b/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { FindMeAnnouncementViewLog } from "@/find-me-announcements/entities/find-me-announcement-get-log.entity";
+
+@Injectable()
+export class FindMeAnnouncementViewLogsService {
+    public constructor(
+        @InjectRepository(FindMeAnnouncementViewLog)
+        private announcementViewLogsRepository: Repository<FindMeAnnouncementViewLog>
+    ) { }
+}

--- a/src/find-me-db/migrations/2022-05-02/1651400454633-AnnouncementsUserViewLogs.ts
+++ b/src/find-me-db/migrations/2022-05-02/1651400454633-AnnouncementsUserViewLogs.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AnnouncementsUserViewLogs1651400454633 implements MigrationInterface {
+    name = 'AnnouncementsUserViewLogs1651400454633'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`find_me_announcement_view_log\` (\`id\` int NOT NULL AUTO_INCREMENT, \`viewDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`viewedAnnouncementId\` int NULL, \`viewingUserId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`find_me_announcement_view_log\` ADD CONSTRAINT \`FK_9260eba33666b50f3187ec55ab9\` FOREIGN KEY (\`viewedAnnouncementId\`) REFERENCES \`find_me_announcement\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`find_me_announcement_view_log\` ADD CONSTRAINT \`FK_f06cedc0cdf1670657afb4b9b1c\` FOREIGN KEY (\`viewingUserId\`) REFERENCES \`find_me_user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`find_me_announcement_view_log\` DROP FOREIGN KEY \`FK_f06cedc0cdf1670657afb4b9b1c\``);
+        await queryRunner.query(`ALTER TABLE \`find_me_announcement_view_log\` DROP FOREIGN KEY \`FK_9260eba33666b50f3187ec55ab9\``);
+        await queryRunner.query(`DROP TABLE \`find_me_announcement_view_log\``);
+    }
+
+}

--- a/src/find-me-users/services/find-me-users-access-log.service.ts
+++ b/src/find-me-users/services/find-me-users-access-log.service.ts
@@ -16,9 +16,10 @@ export class FindMeUsersAccessLogService {
         accessedUser: FindMeUser,
         accessingUser: FindMeUser
     ): Promise<void> {
-        await this.usersAccessLogRepository.create({
+        const accessLog = this.usersAccessLogRepository.create({
             accessedUser: accessedUser,
             accessingUser: accessingUser,
         });
+        await this.usersAccessLogRepository.save(accessLog);
     }
 }


### PR DESCRIPTION
Gdy użytkownik będzie używać endpointu do pobierania ogłoszenia po jego ID i nie będzie jego autorem to w DB zostanie logowane na jakie ogłoszenie wchodzi.

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/39082174/166142046-89521290-fb26-41ab-894f-bc8334d192b0.png">

Ogłoszenie o ID = 2 nie jest autorstwa autoryzowanego użytkownika (155) i logujemy dane kiedy pobierał jakie ogłoszenia 

<img width="542" alt="image" src="https://user-images.githubusercontent.com/39082174/166142062-c73505e3-8e4a-4afd-8d56-e2f4bfefb6b1.png">
