### PR TITLE
FM-269 | Sorting mode addition to announcements query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.29",
+    "version": "0.40.30",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
+++ b/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
@@ -3,6 +3,8 @@ import { IsArray, IsBoolean, IsEnum, IsOptional } from "class-validator";
 
 import { FindMeAnimalGenderEnum } from "@/find-me-announcements/enums/find-me-animal-gender.enum";
 import { FindMeAnnouncementTypeEnum } from "@/find-me-announcements/enums/find-me-announcement-type.enum";
+import { FindMeAnnouncementsSortingModeEnum }
+    from "@/find-me-announcements/enums/find-me-announcements-sorting-mode.enum";
 import { OffsetPaginationDto } from "@/find-me-commons/dto/offset-pagination.dto";
 
 export class SearchFindMeAnnouncementDto extends OffsetPaginationDto {
@@ -38,4 +40,9 @@ export class SearchFindMeAnnouncementDto extends OffsetPaginationDto {
     @IsArray()
     @IsOptional()
     public coatColorsIds?: number[];
+
+    @ApiProperty({ example: FindMeAnnouncementsSortingModeEnum.BY_NEWEST })
+    @IsEnum(FindMeAnnouncementsSortingModeEnum)
+    @IsOptional()
+    public sortingMode?: FindMeAnnouncementsSortingModeEnum;
 }

--- a/src/find-me-announcements/dto/search-my-find-me-announcements.dto.ts
+++ b/src/find-me-announcements/dto/search-my-find-me-announcements.dto.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsBoolean } from "class-validator";
-
-export class SearchMyFindMeMyAnnouncementsDto {
-    @ApiProperty()
-    @IsBoolean()
-    public active: boolean;
-}

--- a/src/find-me-announcements/enums/find-me-announcements-sorting-mode.enum.ts
+++ b/src/find-me-announcements/enums/find-me-announcements-sorting-mode.enum.ts
@@ -1,0 +1,4 @@
+export enum FindMeAnnouncementsSortingModeEnum {
+    BY_OLDEST = "by-oldest",
+    BY_NEWEST = "by-newest",
+}

--- a/src/find-me-announcements/services/find-me-announcements.service.ts
+++ b/src/find-me-announcements/services/find-me-announcements.service.ts
@@ -10,6 +10,8 @@ import { FindMeAnnouncementPhoto } from "@/find-me-announcements/entities/find-m
 import { FindMeCoatColor } from "@/find-me-announcements/entities/find-me-coat-color.entity";
 import { FindMeDistinctiveFeature } from "@/find-me-announcements/entities/find-me-distinctive-feature.entity";
 import { FindMeAnnouncementStatusEnum } from "@/find-me-announcements/enums/find-me-announcement-status.enum";
+import { FindMeAnnouncementsSortingModeEnum }
+    from "@/find-me-announcements/enums/find-me-announcements-sorting-mode.enum";
 import { FindMeFavoriteAnnouncementsService }
     from "@/find-me-announcements/services/find-me-favorite-announcements.service";
 import { ErrorMessagesConstants } from "@/find-me-commons/constants/error-messages.constants";
@@ -193,6 +195,16 @@ export class FindMeAnnouncementsService {
                         .every(coatColorId => announcement.coatColors
                             .map(coatColor => coatColor.id).includes(coatColorId)));
         }
+
+        announcements = announcements.sort((a, b) => {
+            switch (searchDto.sortingMode) {
+                case FindMeAnnouncementsSortingModeEnum.BY_OLDEST:
+                    return a.createDate.getTime() - b.createDate.getTime();
+                case FindMeAnnouncementsSortingModeEnum.BY_NEWEST:
+                default:
+                    return b.createDate.getTime() - a.createDate.getTime();
+            }
+        });
 
         announcements = announcements.filter((_, i) => i >= offset && i < offset + pageSize);
 


### PR DESCRIPTION
Przyjmowane wartości do pola `sortingMode` to `"by-oldest" | "by-newest" | null | undefined` w przypadku braku podania pola `sortingMode` mamy sortowanie od najnowszych (sortowanie domyślne)

```
// Tak wygląda enum na backendzie do sortowania
export enum FindMeAnnouncementsSortingModeEnum {
    BY_OLDEST = "by-oldest",
    BY_NEWEST = "by-newest",
}
```

### Pole w formularzu
<img width="327" alt="image" src="https://user-images.githubusercontent.com/39082174/168469551-5521274e-6c0e-4c9f-a68f-444cefef1af8.png">
