### PR TITLE
FM-257 | Last viewed announcements get endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.32",
+    "version": "0.40.33",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/controllers/find-me-announcements.controller.ts
+++ b/src/find-me-announcements/controllers/find-me-announcements.controller.ts
@@ -130,6 +130,35 @@ export class FindMeAnnouncementsController {
     }
 
     @ApiOperation({
+        summary: "Search user last viewed announcements",
+        description: "You can narrow result using announcements filters",
+    })
+    @ApiOkResponse({
+        description: "Returns array of user last viewed announcements",
+        type: FindMeAnnouncement,
+        isArray: true,
+    })
+    @ApiUnauthorizedResponse({
+        description: "Bad authorization token",
+        type: UnauthorizedExceptionDto,
+    })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    @Post(PathConstants.LAST_VIEWED + "/" + PathConstants.SEARCH)
+    public async searchLastViewedAnnouncements(
+        @CurrentUser() user: FindMeUser,
+        @Body() searchDto: SearchFindMeAnnouncementDto
+    ): Promise<GetFindMeAnnouncementDto[]> {
+        const announcements = await this.announcementsService.searchLastViewedAnnouncements(user, searchDto);
+        return Promise.all(announcements.map(async announcement => ({
+            ...announcement,
+            isInFavorites: await this.favoriteAnnouncementsService.isAnnouncementInUserFavorites(announcement, user),
+            isUserCreator: true,
+            viewsAmount: await this.announcementViewLogsService.getViewLogsAmountForAnnouncements(announcement),
+        })));
+    }
+
+    @ApiOperation({
         summary: "Get other user created announcements by user ID",
         description: "You can narrow result to using announcements filters",
     })

--- a/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
+++ b/src/find-me-announcements/services/find-me-announcement-view-logs.service.ts
@@ -25,4 +25,14 @@ export class FindMeAnnouncementViewLogsService {
         return (await this.announcementViewLogsRepository.find({ where: { viewedAnnouncement: announcement.id } }))
             .length;
     }
+
+    public async getUserAnnouncementsViewLogs(user: FindMeUser): Promise<FindMeAnnouncementViewLog[]> {
+        return this.announcementViewLogsRepository.find({
+            where: { viewingUser: user.id },
+            relations: [
+                "viewingUser",
+                "viewedAnnouncement",
+            ],
+        });
+    }
 }

--- a/src/find-me-commons/constants/path.constants.ts
+++ b/src/find-me-commons/constants/path.constants.ts
@@ -19,6 +19,7 @@ export class PathConstants {
     public static AN = "distinctive-feature";
     public static ME = "me";
     public static MY = "my";
+    public static LAST_VIEWED = "last-viewed";
     public static LOCATION = "location";
     public static LOGIN = "login";
     public static LOGOUT = "logout";


### PR DESCRIPTION
Last viewed announcements are searchable the same way as `my` and `global`.

### Returns newest first!

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/39082174/169504600-ba4c0fb6-95fd-4bae-8fc0-5649a80aab15.png">
