### PR TITLE
FM-279 | Recently created announcements endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.34",
+    "version": "0.40.35",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/controllers/find-me-announcements.controller.ts
+++ b/src/find-me-announcements/controllers/find-me-announcements.controller.ts
@@ -97,6 +97,34 @@ export class FindMeAnnouncementsController {
     }
 
     @ApiOperation({
+        summary: "Search recently created (<= 24h from now) announcements",
+        description: "You can narrow result using announcements filters",
+    })
+    @ApiOkResponse({
+        description: "Returns array of recently created (<= 24h from now) announcements",
+        type: GetFindMeAnnouncementDto,
+        isArray: true,
+    })
+    @ApiUnauthorizedResponse({
+        description: "Bad authorization token",
+        type: UnauthorizedExceptionDto,
+    })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    @Post(PathConstants.RECENTLY_CREATED + "/" + PathConstants.SEARCH)
+    public async searchRecentlyCreatedAnnouncements(
+        @CurrentUser() user: FindMeUser,
+        @Body() searchDto: SearchFindMeAnnouncementDto
+    ): Promise<GetFindMeAnnouncementDto[]> {
+        const recentlyCreatedAnnouncements = await this.announcementsService.searchRecentlyCreatedAnnouncements(
+            user,
+            searchDto
+        );
+
+        return this.parseAnnouncementsObjectsToDto(recentlyCreatedAnnouncements, user);
+    }
+
+    @ApiOperation({
         summary: "Search user created announcements",
         description: "You can narrow result using announcements filters",
     })

--- a/src/find-me-announcements/services/find-me-announcements.service.ts
+++ b/src/find-me-announcements/services/find-me-announcements.service.ts
@@ -163,6 +163,16 @@ export class FindMeAnnouncementsService {
         return this.narrowResultByFilters(announcements, searchingUser, searchDto);
     }
 
+    public async searchRecentlyCreatedAnnouncements(
+        searchingUser: FindMeUser,
+        searchDto: SearchFindMeAnnouncementDto
+    ): Promise<FindMeAnnouncement[]> {
+        const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+        const announcements = (await this.getAllAnnouncements()).filter(announcement =>
+            announcement.createDate.getTime() >= (new Date().getTime() - oneDayInMilliseconds));
+        return this.narrowResultByFilters(announcements, searchingUser, searchDto);
+    }
+
     public async narrowResultByFilters(
         announcements: FindMeAnnouncement[],
         searchingUser: FindMeUser,

--- a/src/find-me-commons/constants/path.constants.ts
+++ b/src/find-me-commons/constants/path.constants.ts
@@ -20,6 +20,7 @@ export class PathConstants {
     public static ME = "me";
     public static MY = "my";
     public static LAST_VIEWED = "last-viewed";
+    public static RECENTLY_CREATED = "recently-created";
     public static LOCATION = "location";
     public static LOGIN = "login";
     public static LOGOUT = "logout";


### PR DESCRIPTION
Endpoint zwraca ogłoszenia dokładnie tak samo jak każdy inny i pozwala używać wszystkich opcji search. Ogłoszenia są limitowane do max 24h od teraz.

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/39082174/170251357-05247882-6219-4af6-a252-bc7a345919a5.png">
