### PR TITLE
FM-282 | Comment to announcements create endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.35",
+    "version": "0.40.36",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.36",
+    "version": "0.40.37",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=src/find-me-db/migrations/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.exclusions=src/find-me-db/migrations/**

--- a/src/find-me-announcements/services/find-me-announcement-photos.service.ts
+++ b/src/find-me-announcements/services/find-me-announcement-photos.service.ts
@@ -12,7 +12,10 @@ export class FindMeAnnouncementPhotosService {
         private announcementPhotosRepository: Repository<FindMeAnnouncementPhoto>
     ) { }
 
-    public async createAnnouncementPhoto(user: FindMeUser, photoUrl: string): Promise<FindMeAnnouncementPhoto> {
+    public async createAnnouncementPhoto(
+        user: FindMeUser,
+        photoUrl: string
+    ): Promise<FindMeAnnouncementPhoto> {
         const announcementPhoto = this.announcementPhotosRepository.create({
             user,
             url: photoUrl,

--- a/src/find-me-announcements/services/find-me-announcements.service.ts
+++ b/src/find-me-announcements/services/find-me-announcements.service.ts
@@ -55,7 +55,7 @@ export class FindMeAnnouncementsService {
             distinctiveFeatures,
             coatColors,
             photos,
-            creator: creator,
+            creator,
         });
         await this.announcementsRepository.save(createdAnnouncement);
         return createdAnnouncement;

--- a/src/find-me-app/find-me-app.module.ts
+++ b/src/find-me-app/find-me-app.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { join } from "path";
 
 import { FindMeAnnouncementsModule } from "@/find-me-announcements/find-me-announcements.module";
+import { FindMeCommentsModule } from "@/find-me-comments/find-me-comments.module";
 import { envConfig } from "@/find-me-commons/configurations/env.config";
 import { securityConfig } from "@/find-me-commons/configurations/security.config";
 import { seederConfig } from "@/find-me-commons/configurations/seeder.config";
@@ -47,6 +48,7 @@ import { FindMeUsersModule } from "@/find-me-users/find-me-users.module";
         FindMeUsersModule,
         FindMeAnnouncementsModule,
         FindMeLocationModule,
+        FindMeCommentsModule,
         // Application modules end
     ],
 })

--- a/src/find-me-comments/controllers/find-me-comment-photos.controller.ts
+++ b/src/find-me-comments/controllers/find-me-comment-photos.controller.ts
@@ -1,0 +1,64 @@
+import { ClassSerializerInterceptor, Controller, Post, UploadedFile, UseGuards, UseInterceptors } from "@nestjs/common";
+import {
+    ApiBearerAuth, ApiBody,
+    ApiConsumes, ApiOkResponse,
+    ApiOperation, ApiTags, ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+
+import { FindMeCommentPhoto } from "@/find-me-comments/entities/find-me-comment-photo.entity";
+import { FindMeCommentPhotosService } from "@/find-me-comments/services/find-me-comments-photos.service";
+import { ApiTagsConstants } from "@/find-me-commons/constants/api-tags.constants";
+import { PathConstants } from "@/find-me-commons/constants/path.constants";
+import { UnauthorizedExceptionDto } from "@/find-me-commons/dto/unauthorized-exception.dto";
+import { CurrentUser } from "@/find-me-security/decorators/find-me-current-user.decorator";
+import { JwtAuthGuard } from "@/find-me-security/guards/find-me-jwt-auth.guard";
+import { FindMeStorageCommentPhotoInterceptor }
+    from "@/find-me-storage/interceptors/find-me-storage-comment-photo.interceptor";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+@ApiTags(ApiTagsConstants.COMMENT_PHOTOS)
+@UseInterceptors(ClassSerializerInterceptor)
+@Controller(PathConstants.COMMENT_PHOTOS)
+export class FindMeCommentPhotosController {
+    public constructor(
+        private commentPhotosService: FindMeCommentPhotosService
+    ) { }
+
+    @ApiOperation({
+        summary: "Upload one comment photo",
+        description: "Upload one comment photo and returns its object",
+    })
+    @ApiConsumes("multipart/form-data")
+    @ApiBody({
+        schema: {
+            type: "object",
+            properties: {
+                file: {
+                    type: "string",
+                    format: "binary",
+                },
+            },
+        },
+    })
+    @ApiUnauthorizedResponse({
+        description: "Bad authorization token",
+        type: UnauthorizedExceptionDto,
+    })
+    @ApiOkResponse({
+        description: "Successfully uploaded photo and returns photo object",
+        type: FindMeCommentPhoto,
+    })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    @UseInterceptors(FindMeStorageCommentPhotoInterceptor)
+    @Post(PathConstants.UPLOAD)
+    public async uploadAnnouncementPhoto(
+        @UploadedFile() file: Express.Multer.File,
+        @CurrentUser() user: FindMeUser
+    ): Promise<FindMeCommentPhoto> {
+        return this.commentPhotosService.createCommentPhoto(
+            user,
+            file.path.replaceAll("\\", "/")
+        );
+    }
+}

--- a/src/find-me-comments/controllers/find-me-comments.controller.ts
+++ b/src/find-me-comments/controllers/find-me-comments.controller.ts
@@ -1,0 +1,55 @@
+import { Body, ClassSerializerInterceptor, Controller, Post, UseGuards, UseInterceptors } from "@nestjs/common";
+import {
+    ApiBearerAuth, ApiNotFoundResponse,
+    ApiOkResponse, ApiOperation,
+    ApiTags, ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+
+import { CreateFindMeCommentDto } from "@/find-me-comments/dto/create-find-me-comment.dto";
+import { FindMeComment } from "@/find-me-comments/entities/find-me-comment.entity";
+import { FindMeCommentsService } from "@/find-me-comments/services/find-me-comments.service";
+import { ApiTagsConstants } from "@/find-me-commons/constants/api-tags.constants";
+import { PathConstants } from "@/find-me-commons/constants/path.constants";
+import { BadRequestExceptionDto } from "@/find-me-commons/dto/bad-request-exception.dto";
+import { UnauthorizedExceptionDto } from "@/find-me-commons/dto/unauthorized-exception.dto";
+import { CurrentUser } from "@/find-me-security/decorators/find-me-current-user.decorator";
+import { JwtAuthGuard } from "@/find-me-security/guards/find-me-jwt-auth.guard";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+@ApiTags(ApiTagsConstants.COMMENTS)
+@UseInterceptors(ClassSerializerInterceptor)
+@Controller(PathConstants.COMMENTS)
+export class FindMeCommentsController {
+    public constructor(
+        private commentsService: FindMeCommentsService
+    ) { }
+
+    @ApiOperation({
+        summary: "Create new announcement comment",
+        description: "Creates new announcement comment and returns it",
+    })
+    @ApiOkResponse({
+        description: "Successfully created announcement comment",
+        type: FindMeComment,
+    })
+    @ApiNotFoundResponse({
+        description: "Form validation error array",
+        type: BadRequestExceptionDto,
+    })
+    @ApiUnauthorizedResponse({
+        description: "Bad authorization token",
+        type: UnauthorizedExceptionDto,
+    })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    @Post()
+    public async createAnnouncement(
+        @CurrentUser() user: FindMeUser,
+        @Body() createDto: CreateFindMeCommentDto
+    ): Promise<FindMeComment> {
+        return this.commentsService.createComment(
+            user,
+            createDto
+        );
+    }
+}

--- a/src/find-me-comments/dto/create-find-me-comment.dto.ts
+++ b/src/find-me-comments/dto/create-find-me-comment.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsPositive, IsString } from "class-validator";
+
+export class CreateFindMeCommentDto {
+    @ApiProperty({ example: 1 })
+    @IsPositive()
+    @IsNumber()
+    public commentedAnnouncementId: number;
+
+    @ApiProperty({ example: "Widziałam tego pieska!" })
+    @IsNotEmpty()
+    @IsString()
+    public comment: string;
+
+    @ApiProperty({ example: 50.0469432 })
+    @IsNumber()
+    @IsOptional()
+    public locationLat?: number;
+
+    @ApiProperty({ example: 19.997153435836697 })
+    @IsNumber()
+    @IsOptional()
+    public locationLot?: number;
+
+    @ApiProperty({ example: [] })
+    @IsArray()
+    public photosIds: number[];
+}

--- a/src/find-me-comments/entities/find-me-comment-photo.entity.ts
+++ b/src/find-me-comments/entities/find-me-comment-photo.entity.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { envConfig } from "@/find-me-commons/configurations/env.config";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+@Entity()
+export class FindMeCommentPhoto {
+    @ApiProperty()
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+    @ApiProperty()
+    @Transform(({ value }) => value ? envConfig().rootUrl + value : value)
+    @Column()
+    public url: string;
+
+    @ApiProperty()
+    @ManyToOne(() => FindMeUser)
+    public user: FindMeUser;
+
+    @ApiProperty()
+    @CreateDateColumn()
+    public created: Date;
+}

--- a/src/find-me-comments/entities/find-me-comment.entity.ts
+++ b/src/find-me-comments/entities/find-me-comment.entity.ts
@@ -1,6 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinTable, ManyToMany, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
+import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
+import { FindMeCommentPhoto } from "@/find-me-comments/entities/find-me-comment-photo.entity";
 import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
 
 @Entity()
@@ -8,6 +10,10 @@ export class FindMeComment {
     @ApiProperty()
     @PrimaryGeneratedColumn()
     public id: number;
+
+    @ApiProperty()
+    @ManyToOne(() => FindMeAnnouncement)
+    public commentedAnnouncement: FindMeAnnouncement;
 
     @ApiProperty()
     @Column({ nullable: false })
@@ -34,10 +40,15 @@ export class FindMeComment {
     public creator: FindMeUser;
 
     @ApiProperty()
+    @ManyToMany(() => FindMeCommentPhoto)
+    @JoinTable({ name: "find-me-bind-comment-photos" })
+    public photos: FindMeCommentPhoto[];
+
+    @ApiProperty()
     @CreateDateColumn()
     public createDate: Date;
 
     @ApiProperty()
     @Column({ default: false })
-    public archived :boolean;
+    public archived: boolean;
 }

--- a/src/find-me-comments/entities/find-me-comment.entity.ts
+++ b/src/find-me-comments/entities/find-me-comment.entity.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+@Entity()
+export class FindMeComment {
+    @ApiProperty()
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+    @ApiProperty()
+    @Column({ nullable: false })
+    public comment: string;
+
+    @ApiProperty()
+    @Column({
+        type: "decimal",
+        precision: 8,
+        scale: 6,
+    })
+    public locationLat: number;
+
+    @ApiProperty()
+    @Column({
+        type: "decimal",
+        precision: 9,
+        scale: 6,
+    })
+    public locationLon: number;
+
+    @ApiProperty()
+    @ManyToOne(() => FindMeUser)
+    public creator: FindMeUser;
+
+    @ApiProperty()
+    @CreateDateColumn()
+    public createDate: Date;
+
+    @ApiProperty()
+    @Column({ default: false })
+    public archived :boolean;
+}

--- a/src/find-me-comments/find-me-comments.module.ts
+++ b/src/find-me-comments/find-me-comments.module.ts
@@ -1,0 +1,4 @@
+import { Module } from "@nestjs/common";
+
+@Module({})
+export class FindMeCommentsModule { }

--- a/src/find-me-comments/find-me-comments.module.ts
+++ b/src/find-me-comments/find-me-comments.module.ts
@@ -1,4 +1,27 @@
 import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
-@Module({})
+import { FindMeCommentPhotosController } from "@/find-me-comments/controllers/find-me-comment-photos.controller";
+import { FindMeCommentsController } from "@/find-me-comments/controllers/find-me-comments.controller";
+import { FindMeComment } from "@/find-me-comments/entities/find-me-comment.entity";
+import { FindMeCommentPhoto } from "@/find-me-comments/entities/find-me-comment-photo.entity";
+import { FindMeCommentsService } from "@/find-me-comments/services/find-me-comments.service";
+import { FindMeCommentPhotosService } from "@/find-me-comments/services/find-me-comments-photos.service";
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([
+            FindMeCommentPhoto,
+            FindMeComment,
+        ]),
+    ],
+    providers: [
+        FindMeCommentPhotosService,
+        FindMeCommentsService,
+    ],
+    controllers: [
+        FindMeCommentPhotosController,
+        FindMeCommentsController,
+    ],
+})
 export class FindMeCommentsModule { }

--- a/src/find-me-comments/services/find-me-comments-photos.service.ts
+++ b/src/find-me-comments/services/find-me-comments-photos.service.ts
@@ -1,0 +1,24 @@
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { FindMeCommentPhoto } from "@/find-me-comments/entities/find-me-comment-photo.entity";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+export class FindMeCommentPhotosService {
+    public constructor(
+        @InjectRepository(FindMeCommentPhoto)
+        private commentPhotosRepository: Repository<FindMeCommentPhoto>
+    ) { }
+
+    public async createCommentPhoto(
+        user: FindMeUser,
+        photoUrl: string
+    ): Promise<FindMeCommentPhoto> {
+        const commentPhoto = this.commentPhotosRepository.create({
+            user,
+            url: photoUrl,
+        });
+        await this.commentPhotosRepository.save(commentPhoto);
+        return commentPhoto;
+    }
+}

--- a/src/find-me-comments/services/find-me-comments.service.ts
+++ b/src/find-me-comments/services/find-me-comments.service.ts
@@ -1,0 +1,33 @@
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+
+import { CreateFindMeCommentDto } from "@/find-me-comments/dto/create-find-me-comment.dto";
+import { FindMeComment } from "@/find-me-comments/entities/find-me-comment.entity";
+import { FindMeUser } from "@/find-me-users/entities/find-me-user.entity";
+
+export class FindMeCommentsService {
+    public constructor(
+        @InjectRepository(FindMeComment)
+        private commentsRepository: Repository<FindMeComment>
+    ) { }
+
+    public async createComment(
+        creator: FindMeUser,
+        createDto: CreateFindMeCommentDto
+    ): Promise<FindMeComment> {
+        const commentedAnnouncement = { id: createDto.commentedAnnouncementId };
+        const photos = createDto.photosIds
+            .map(photoIds => ({ id: photoIds }));
+
+        const createdComment = this.commentsRepository.create({
+            comment: createDto.comment,
+            locationLon: createDto.locationLot,
+            locationLat: createDto.locationLat,
+            commentedAnnouncement,
+            photos,
+            creator,
+        });
+        await this.commentsRepository.save(createdComment);
+        return createdComment;
+    }
+}

--- a/src/find-me-commons/constants/api-tags.constants.ts
+++ b/src/find-me-commons/constants/api-tags.constants.ts
@@ -9,4 +9,6 @@ export class ApiTagsConstants {
     public static ANNOUNCEMENTS = "announcements";
     public static COAT_COLORS = "coat-colors";
     public static LOCATION = "location";
+    public static COMMENT_PHOTOS = "comment-photos";
+    public static COMMENTS = "comments";
 }

--- a/src/find-me-commons/constants/path.constants.ts
+++ b/src/find-me-commons/constants/path.constants.ts
@@ -37,4 +37,6 @@ export class PathConstants {
     public static RESOLVE = "resolve";
     public static MAKE_ACTIVE = "make-active";
     public static ARCHIVE = "archive";
+    public static COMMENT_PHOTOS = "comment-photos";
+    public static COMMENTS = "comments";
 }

--- a/src/find-me-db/migrations/2022-05-32/1654019432679-CommentsWithCommentPhotos.ts
+++ b/src/find-me-db/migrations/2022-05-32/1654019432679-CommentsWithCommentPhotos.ts
@@ -1,0 +1,30 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CommentsWithCommentPhotos1654019432679 implements MigrationInterface {
+    name = 'CommentsWithCommentPhotos1654019432679'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`find_me_comment_photo\` (\`id\` int NOT NULL AUTO_INCREMENT, \`url\` varchar(255) NOT NULL, \`created\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`userId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`find_me_comment\` (\`id\` int NOT NULL AUTO_INCREMENT, \`comment\` varchar(255) NOT NULL, \`locationLat\` decimal(8,6) NOT NULL, \`locationLon\` decimal(9,6) NOT NULL, \`createDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`archived\` tinyint NOT NULL DEFAULT 0, \`commentedAnnouncementId\` int NULL, \`creatorId\` int NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`find-me-bind-comment-photos\` (\`findMeCommentId\` int NOT NULL, \`findMeCommentPhotoId\` int NOT NULL, INDEX \`IDX_1b56c8c1a7dd8d37a4158db51a\` (\`findMeCommentId\`), INDEX \`IDX_53802b0626b2cdb2d1a57f2096\` (\`findMeCommentPhotoId\`), PRIMARY KEY (\`findMeCommentId\`, \`findMeCommentPhotoId\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment_photo\` ADD CONSTRAINT \`FK_3848f4d2a2639551c1258fd0f36\` FOREIGN KEY (\`userId\`) REFERENCES \`find_me_user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment\` ADD CONSTRAINT \`FK_7d4a8197339071c9479a74dac55\` FOREIGN KEY (\`commentedAnnouncementId\`) REFERENCES \`find_me_announcement\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment\` ADD CONSTRAINT \`FK_2e6e9743caa23f797c739f9fdc5\` FOREIGN KEY (\`creatorId\`) REFERENCES \`find_me_user\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`find-me-bind-comment-photos\` ADD CONSTRAINT \`FK_1b56c8c1a7dd8d37a4158db51ab\` FOREIGN KEY (\`findMeCommentId\`) REFERENCES \`find_me_comment\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE \`find-me-bind-comment-photos\` ADD CONSTRAINT \`FK_53802b0626b2cdb2d1a57f20966\` FOREIGN KEY (\`findMeCommentPhotoId\`) REFERENCES \`find_me_comment_photo\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`find-me-bind-comment-photos\` DROP FOREIGN KEY \`FK_53802b0626b2cdb2d1a57f20966\``);
+        await queryRunner.query(`ALTER TABLE \`find-me-bind-comment-photos\` DROP FOREIGN KEY \`FK_1b56c8c1a7dd8d37a4158db51ab\``);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment\` DROP FOREIGN KEY \`FK_2e6e9743caa23f797c739f9fdc5\``);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment\` DROP FOREIGN KEY \`FK_7d4a8197339071c9479a74dac55\``);
+        await queryRunner.query(`ALTER TABLE \`find_me_comment_photo\` DROP FOREIGN KEY \`FK_3848f4d2a2639551c1258fd0f36\``);
+        await queryRunner.query(`DROP INDEX \`IDX_53802b0626b2cdb2d1a57f2096\` ON \`find-me-bind-comment-photos\``);
+        await queryRunner.query(`DROP INDEX \`IDX_1b56c8c1a7dd8d37a4158db51a\` ON \`find-me-bind-comment-photos\``);
+        await queryRunner.query(`DROP TABLE \`find-me-bind-comment-photos\``);
+        await queryRunner.query(`DROP TABLE \`find_me_comment\``);
+        await queryRunner.query(`DROP TABLE \`find_me_comment_photo\``);
+    }
+
+}

--- a/src/find-me-storage/interceptors/find-me-storage-comment-photo.interceptor.ts
+++ b/src/find-me-storage/interceptors/find-me-storage-comment-photo.interceptor.ts
@@ -1,0 +1,15 @@
+import { FileInterceptor } from "@nestjs/platform-express";
+import { diskStorage } from "multer";
+import { extname } from "path";
+import { v4 as uuidv4 } from "uuid";
+
+export const FindMeStorageCommentPhotoInterceptor = FileInterceptor("file", {
+    storage: diskStorage({
+        destination: "./storage/comment-photos",
+        filename: (_req, file, callback) => {
+            const fileExtName = extname(file.originalname);
+            const fileName = uuidv4();
+            callback(null, `${fileName}-comment-photo${fileExtName}`);
+        },
+    }),
+});


### PR DESCRIPTION
Komentarze ze zdjęciami tworzymy tak samo jak ogłoszenia - najpierw wysyłamy zdjęcia na endpoint i zapisujemy sobie w formularzu ich zwrócone ID a potem jako tablice idków wysyłamy w formularzu tworzenia komentarza do ogłoszenia.

<img width="788" alt="image" src="https://user-images.githubusercontent.com/39082174/171259213-fb0cc827-e23d-4ea3-b2f4-3b9df6a594c8.png">
