### PR TITLE
FM-297 | Get announcements nearby endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-me-server",
-    "version": "0.40.43",
+    "version": "0.40.44",
     "private": true,
     "author": "Findock",
     "scripts": {

--- a/src/find-me-announcements/controllers/find-me-announcements.controller.ts
+++ b/src/find-me-announcements/controllers/find-me-announcements.controller.ts
@@ -15,6 +15,7 @@ import {
 import { CreateFindMeAnnouncementDto } from "@/find-me-announcements/dto/create-find-me-announcement.dto";
 import { GetFindMeAnnouncementDto } from "@/find-me-announcements/dto/get-find-me-announcement-dto";
 import { SearchFindMeAnnouncementDto } from "@/find-me-announcements/dto/search-find-me-announcement.dto";
+import { SearchNearbyMeAnnouncementDto } from "@/find-me-announcements/dto/search-nearby-find-me-announcement-dto";
 import { FindMeAnnouncement } from "@/find-me-announcements/entities/find-me-announcement.entity";
 import { FindMeAnnouncementViewLogsService }
     from "@/find-me-announcements/services/find-me-announcement-view-logs.service";
@@ -119,6 +120,33 @@ export class FindMeAnnouncementsController {
         const recentlyCreatedAnnouncements = await this.announcementsService.searchRecentlyCreatedAnnouncements(
             user,
             searchDto
+        );
+
+        return this.parseAnnouncementsObjectsToDto(recentlyCreatedAnnouncements, user);
+    }
+
+    @ApiOperation({
+        summary: "Search nearby (less than 20km) announcements",
+        description: "You can narrow result using announcements filters",
+    })
+    @ApiOkResponse({
+        description: "Returns nearby (less than 20km) announcements",
+        type: GetFindMeAnnouncementDto,
+        isArray: true,
+    })
+    @ApiUnauthorizedResponse({
+        description: "Bad authorization token",
+        type: UnauthorizedExceptionDto,
+    })
+    @ApiBearerAuth()
+    @UseGuards(JwtAuthGuard)
+    @Post(PathConstants.NEARBY + "/" + PathConstants.SEARCH)
+    public async searchNearbyAnnouncements(
+        @CurrentUser() user: FindMeUser,
+        @Body() searchDtoWithoutLocation: SearchNearbyMeAnnouncementDto
+    ): Promise<GetFindMeAnnouncementDto[]> {
+        const recentlyCreatedAnnouncements = await this.announcementsService.searchNearbyAnnouncements(
+            searchDtoWithoutLocation
         );
 
         return this.parseAnnouncementsObjectsToDto(recentlyCreatedAnnouncements, user);

--- a/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
+++ b/src/find-me-announcements/dto/search-find-me-announcement.dto.ts
@@ -10,10 +10,12 @@ import { OffsetPaginationDto } from "@/find-me-commons/dto/offset-pagination.dto
 export class SearchFindMeAnnouncementDto extends OffsetPaginationDto {
     @ApiProperty({ example: false })
     @IsBoolean()
+    @IsOptional()
     public onlyActive?: boolean;
 
     @ApiProperty({ example: false })
     @IsBoolean()
+    @IsOptional()
     public onlyFavorites?: boolean;
 
     @ApiProperty({ example: [ 1 ] })

--- a/src/find-me-announcements/dto/search-nearby-find-me-announcement-dto.ts
+++ b/src/find-me-announcements/dto/search-nearby-find-me-announcement-dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNumber } from "class-validator";
+
+import { OffsetPaginationDto } from "@/find-me-commons/dto/offset-pagination.dto";
+
+export class SearchNearbyMeAnnouncementDto extends OffsetPaginationDto {
+    @ApiProperty({ example: 50.0469432 })
+    @IsNumber()
+    public locationLat: number;
+
+    @ApiProperty({ example: 19.997153435836697 })
+    @IsNumber()
+    public locationLon: number;
+}

--- a/src/find-me-commons/constants/path.constants.ts
+++ b/src/find-me-commons/constants/path.constants.ts
@@ -40,4 +40,5 @@ export class PathConstants {
     public static COMMENT_PHOTOS = "comment-photos";
     public static COMMENTS = "comments";
     public static TO_ANNOUNCEMENT = "to-announcement";
+    public static NEARBY = "nearby";
 }


### PR DESCRIPTION
Endpoint do pobierania ogłoszeń w okolicy (20km), trzeba podać paginację oraz punkt centralny, od którego określamy okolicę (koorynaty lot/lan)

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/39082174/172050848-08522dc8-9b82-48e4-8651-1f5fb04ea949.png">
